### PR TITLE
Add start script for local OS X runs

### DIFF
--- a/package-maker/src/main/resources/bin/start_local_osx.sh
+++ b/package-maker/src/main/resources/bin/start_local_osx.sh
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2015 Agro-Know, Deutsches Forschungszentrum für Künstliche Intelligenz, iMinds,
+# Institut für Angewandte Informatik e. V. an der Universität Leipzig,
+# Istituto Superiore Mario Boella, Tilde, Vistatec, WRIPL (http://freme-project.eu)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# NOTE: you need to have GNU coreutils available on your machine for this to work: `brew install coreutils`
+SCRIPT=$(greadlink -f "$0")
+BASEDIR=$(dirname "$SCRIPT")
+cd "$BASEDIR"/..
+
+java -cp "./*:../classes:config" org.springframework.boot.loader.JarLauncher


### PR DESCRIPTION
- OS X doesn't support -f in readlink, but with the GNU version (greadlink), it works as expected
- I had to add "../classes" to the classpath, not sure why